### PR TITLE
smoothing out com5003 ZeraAll export a little.

### DIFF
--- a/zeraconverterengines/MTVisRes.py
+++ b/zeraconverterengines/MTVisRes.py
@@ -781,16 +781,20 @@ class UserScript:
         funcList.append(self.convertZeraGuiCurrentBurden)
         funcList.append(self.convertZeraGuiInstrumentTransformer)
         for func in funcList:
-            ret=func(input,metadata)
-            if type(ret) is list:
-                for ele in ret:
+            try:
+                ret=func(input,metadata)
+                if type(ret) is list:
+                    for ele in ret:
+                        res=dict()
+                        res=ele
+                        endResult.append(res)
+                elif type(ret) is dict:
                     res=dict()
-                    res=ele
+                    res=ret
                     endResult.append(res)
-            elif type(ret) is dict:
+            except BaseException as err:
+                logging.warning("Converting transaction failed with: "+str(err))
                 res=dict()
-                res=ret
-                endResult.append(res)
 
         return endResult
 


### PR DESCRIPTION
ZeraAll MTVis export would not work on com5003 because
needed components are missing in different sessions.
To make it work as good as possible python-converter will
convert at least all possible transactions now.

igned-off-by: bhamacher <b.hamacher@zera.de>