### PR TITLE
Fixing range issues.

### DIFF
--- a/zeraconverterengines/Common.py
+++ b/zeraconverterengines/Common.py
@@ -70,12 +70,12 @@ def UnitNumberSeperator(string):
     retVal["value"]=0
     retVal["unit"]=""
     try:
-        exp=re.match("^([-+]{0,1})([1-9]{1,1}[0-9]*[\.,]{0,1}[0-9]*)\s*([aA-zZ]*)$",string)
-        tmp=str(exp.group(1))+str(exp.group(2))
+        exp=re.match("^([aA-zZ]*)([-+]{0,1})([1-9]{1,1}[0-9]*[\.,]{0,1}[0-9]*)\s*([aA-zZ]*)$",string)
+        tmp=str(exp.group(2))+str(exp.group(3))
         tmp=tmp.replace(",",".")
         retVal["value"]=float(tmp)
-        retVal["unit"]=exp.group(3)
-    except:
+        retVal["unit"]=exp.group(4)
+    except :
         retVal["value"]=0
         retVal["unit"]=""
     return retVal

--- a/zeraconverterengines/MTVisRes.py
+++ b/zeraconverterengines/MTVisRes.py
@@ -181,7 +181,7 @@ class UserScript:
         eleList=list()
         URange=float(0)
         IRange=float(0)
-        for c in range(1,4):
+        for c in range(1,3):
             uDictVal=zeracom.UnitNumberSeperator(vals["RangeModule1"]["PAR_Channel"+ str(c)+"Range"])
             iDictVal=zeracom.UnitNumberSeperator(vals["RangeModule1"]["PAR_Channel"+ str(c+3)+"Range"])
             if URange < uDictVal["value"]:


### PR DESCRIPTION
The converter was not able to extract clamp ranges properly
because they would start with the character "C". The regexp in Common.py
accepts any kind of prefix now. Furthermore the aux channel range is ignored and the
range is iterated form channel 1-3/4-6 now.

Signed-off-by: bhamacher <b.hamacher@zera.de>