### PR TITLE
Impulses are a whole number and do not need to be treated differently.

### DIFF
--- a/zeraconverterengines/MTVisRes.py
+++ b/zeraconverterengines/MTVisRes.py
@@ -545,7 +545,7 @@ class UserScript:
 
         # eleList.append({"RF" : ""})
         eleList.append({"Cz" :  self.formatNumber(vals["SEC1Module1"]["PAR_DutConstant"])+";"+"x1"+";"+ self.formatNumber(vals["SEC1Module1"]["PAR_DUTConstUnit"])})
-        eleList.append({"M-Puls" :  self.formatNumber(vals["SEC1Module1"]["PAR_MRate"])})
+        eleList.append({"M-Puls" :  str(vals["SEC1Module1"]["PAR_MRate"])})
         eleList.append({"M-Inp" : self.formatNumber(vals["SEC1Module1"]["PAR_DutInput"])})
         eleList.append({"Error" :  self.formatNumber(vals["SEC1Module1"]["ACT_Result"])})
         eleList.append({"N-Value" : ""})


### PR DESCRIPTION
Removed format number from pulses in meter-test conversion.

Arthur wanted the decimal places removed.

signed-off-by: bhamacher <b.hamacher@zera.de>