### PR TITLE
More stddev

### DIFF
--- a/zeraconverterengines/MTVisRes.py
+++ b/zeraconverterengines/MTVisRes.py
@@ -555,10 +555,7 @@ class UserScript:
             eleList.append({"N-Value" : str(vals["SEC1Module1"]["PAR_MeasCount"])})
             eleList.append({"Spread" : ""})
             eleList.append({"Average" : self.formatNumber(multimeas["mean"])+"%"})
-            if vals["SEC1Module1"]["PAR_MeasCount"] > 2:
-                eleList.append({"Deviation" : self.formatNumber(multimeas["stddevN1"])+"%"})
-            else:
-                eleList.append({"Deviation" : self.formatNumber(multimeas["stddevN"])+"%"})
+            eleList.append({"Deviation" : self.formatNumber(multimeas["stddevN1"])+"%"})
 
         result["#childs"]=eleList
         return result

--- a/zeraconverterengines/MTVisRes.py
+++ b/zeraconverterengines/MTVisRes.py
@@ -556,8 +556,9 @@ class UserScript:
         if totalCount > 1:
             eleList.append({"N-Value" : str(totalCount)})
             eleList.append({"Spread" : ""})
-            eleList.append({"Average" : self.formatNumber(multimeas["mean"])+"%"})
-            eleList.append({"Deviation" : self.formatNumber(multimeas["stddevN1"])+"%"})
+            # In case we store multi measurement with no power, all results are NaN/null here
+            eleList.append({"Average" : self.formatNumber(multimeas["mean"])+"%" if multimeas["mean"] else "---"})
+            eleList.append({"Deviation" : self.formatNumber(multimeas["stddevN1"])+"%"} if multimeas["stddevN1"] else "---")
 
         result["#childs"]=eleList
         return result

--- a/zeraconverterengines/MTVisRes.py
+++ b/zeraconverterengines/MTVisRes.py
@@ -550,9 +550,11 @@ class UserScript:
         eleList.append({"M-Puls" :  str(vals["SEC1Module1"]["PAR_MRate"])})
         eleList.append({"M-Inp" : self.formatNumber(vals["SEC1Module1"]["PAR_DutInput"])})
         eleList.append({"Error" :  self.formatNumber(vals["SEC1Module1"]["ACT_Result"])}+"%")
-        if vals["SEC1Module1"]["PAR_MeasCount"] > 1:
-            multimeas=json.loads(vals["SEC1Module1"]["ACT_MulResult"])
-            eleList.append({"N-Value" : str(vals["SEC1Module1"]["PAR_MeasCount"])})
+        multimeas=json.loads(vals["SEC1Module1"]["ACT_MulResult"])
+        # maybe we should think about a totalCount in ACT_MulResult...
+        totalCount = int(multimeas["countFail"]) + int(multimeas["countPass"]) + int(multimeas["countUnfinish"])
+        if totalCount > 1:
+            eleList.append({"N-Value" : str(totalCount)})
             eleList.append({"Spread" : ""})
             eleList.append({"Average" : self.formatNumber(multimeas["mean"])+"%"})
             eleList.append({"Deviation" : self.formatNumber(multimeas["stddevN1"])+"%"})


### PR DESCRIPTION
Some commits:

1. Do not swap the standard deviations N -> N-1 (Arthur's) email
2. Extract number of measurements performed properly
3. Handle (valid) null values in stddev/mean

I attached a database with the following sessions (one snapshot each / most taken at context comparison measurement / tested with changes suggested here):

* **'null-values'**: created by measurements with no load on MT -> fails to export
* **'no-values'**: Set PAR_MeasCount to 5 but no measurement performed -> fails to export
* **'ok'**: 5 passed measurements  -> fails to export
* **'zera-all'**: same  as 'ok' **but taken in ZeraAll context**  -> passes export

**Interesting:** The only session NOT failing on export is 'zera-all'. Since it is same as 'ok' and 'ok' fails I assume comparison measurement is not exported in ZeraAll context

I would have fixed errors but you have to introduce me into the art of export-debugging

[test.db.txt](https://github.com/ZeraGmbH/python-converter/files/6110617/test.db.txt)
