### PR TITLE
Fixed date bug for german location.

### DIFF
--- a/zeraconverterengines/MTVisRes.py
+++ b/zeraconverterengines/MTVisRes.py
@@ -168,7 +168,7 @@ class UserScript:
             date=datetimeObj.strftime("%m.%d.%Y")
         elif "de" in self.__local:
             time=datetimeObj.strftime("%H:%M:%S")
-            date=datetimeObj.strftime("%H:%M:%S")
+            date=datetimeObj.strftime("%d.%m.%Y")
         else:
             time=datetimeObj.strftime("%H:%M:%S")
             date=datetimeObj.strftime("%m.%d.%Y")           


### PR DESCRIPTION
The documentation team found this bug. Arthur called me and I fixed it.
The date for the german location flag was the time. Copy paste mistake I guess.

Signed-off-by: bhamacher <b.hamacher@zera.de>